### PR TITLE
Allow using a custom AndroidManifest.xml.in file

### DIFF
--- a/AddQtAndroidApk.cmake
+++ b/AddQtAndroidApk.cmake
@@ -76,7 +76,7 @@ include(CMakeParseArguments)
 macro(add_qt_android_apk TARGET SOURCE_TARGET)
 
     # parse the macro arguments
-    cmake_parse_arguments(ARG "INSTALL" "NAME;PACKAGE_NAME;PACKAGE_SOURCES;KEYSTORE_PASSWORD" "DEPENDS;KEYSTORE" ${ARGN})
+    cmake_parse_arguments(ARG "INSTALL" "NAME;PACKAGE_NAME;PACKAGE_SOURCES;PACKAGE_MANIFEST;KEYSTORE_PASSWORD" "DEPENDS;KEYSTORE" ${ARGN})
 
     # check the configuration
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -120,7 +120,10 @@ macro(add_qt_android_apk TARGET SOURCE_TARGET)
         set(QT_ANDROID_APP_PACKAGE_SOURCE_ROOT "${CMAKE_CURRENT_BINARY_DIR}/package")
 
         # generate a manifest from the template
-        configure_file(${QT_ANDROID_SOURCE_DIR}/AndroidManifest.xml.in ${QT_ANDROID_APP_PACKAGE_SOURCE_ROOT}/AndroidManifest.xml @ONLY)
+        if (NOT ARG_PACKAGE_MANIFEST)
+            set(PACKAGE_MANIFEST ${QT_ANDROID_SOURCE_DIR}/AndroidManifest.xml.in)
+        endif()
+        configure_file(${PACKAGE_MANIFEST} ${QT_ANDROID_APP_PACKAGE_SOURCE_ROOT}/AndroidManifest.xml @ONLY)
     endif()
 
     # set the list of dependant libraries

--- a/readme.md
+++ b/readme.md
@@ -118,27 +118,13 @@ add_qt_android_apk(my_app_apk my_app
 
 The path to a directory containing additional files for the package (custom manifest, resources, translations, Java classes, ...). If you were using a regular QMake project file (.pro), this directory would be the one that you assign to the  ```ANDROID_PACKAGE_SOURCE_DIR``` variable.
 
-If you don't provide this argument, a default manifest is generated from a template file (see PACKAGE_MANIFEST) and automatically used for building the APK.
-
-Example:
-
-```cmake
-add_qt_android_apk(my_app_apk my_app
-    PACKAGE_SOURCES ${CMAKE_CURRENT_LIST_DIR}/my-android-sources
-)
-```
-
-### PACKAGE_MANIFEST
-
-A custom manifest file to use instead of the ```AndroidManifest.xml.in``` template. This option has no effect if ```PACKAGE_SOURCES``` is specified.
-
 If you don't provide this argument, a default manifest is generated from the ```AndroidManifest.xml.in``` template and automatically used for building the APK.
 
 Example:
 
 ```cmake
 add_qt_android_apk(my_app_apk my_app
-    PACKAGE_MANIFEST ${CMAKE_CURRENT_SOURCE_DIR}/AndroidManifest.xml.in
+    PACKAGE_SOURCES ${CMAKE_CURRENT_LIST_DIR}/my-android-sources
 )
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -118,13 +118,27 @@ add_qt_android_apk(my_app_apk my_app
 
 The path to a directory containing additional files for the package (custom manifest, resources, translations, Java classes, ...). If you were using a regular QMake project file (.pro), this directory would be the one that you assign to the  ```ANDROID_PACKAGE_SOURCE_DIR``` variable.
 
-If you don't provide this argument, a default manifest is generated from the ```AndroidManifest.xml.in``` template and automatically used for building the APK.
+If you don't provide this argument, a default manifest is generated from a template file (see PACKAGE_MANIFEST) and automatically used for building the APK.
 
 Example:
 
 ```cmake
 add_qt_android_apk(my_app_apk my_app
     PACKAGE_SOURCES ${CMAKE_CURRENT_LIST_DIR}/my-android-sources
+)
+```
+
+### PACKAGE_MANIFEST
+
+A custom manifest file to use instead of the ```AndroidManifest.xml.in``` template. This option has no effect if ```PACKAGE_SOURCES``` is specified.
+
+If you don't provide this argument, a default manifest is generated from the ```AndroidManifest.xml.in``` template and automatically used for building the APK.
+
+Example:
+
+```cmake
+add_qt_android_apk(my_app_apk my_app
+    PACKAGE_MANIFEST ${CMAKE_CURRENT_SOURCE_DIR}/AndroidManifest.xml.in
 )
 ```
 


### PR DESCRIPTION
To use a custom AndroidManifest.xml.in, pass it via the
PACKAGE_MANIFEST argument of add_qt_android_apk. If PACKAGE_MANIFEST is
not specified, AndroidManifest.xml.in from qt-android-cmake is used.
