### PR TITLE
Invoke add_qt_android_apk during install phase

### DIFF
--- a/AddQtAndroidApk.cmake
+++ b/AddQtAndroidApk.cmake
@@ -76,7 +76,7 @@ include(CMakeParseArguments)
 macro(add_qt_android_apk TARGET SOURCE_TARGET)
 
     # parse the macro arguments
-    cmake_parse_arguments(ARG "INSTALL" "NAME;PACKAGE_NAME;PACKAGE_SOURCES;KEYSTORE_PASSWORD" "DEPENDS;KEYSTORE" ${ARGN})
+    cmake_parse_arguments(ARG "INSTALL;TARGET_INSTALL" "NAME;PACKAGE_NAME;PACKAGE_SOURCES;KEYSTORE_PASSWORD" "DEPENDS;KEYSTORE" ${ARGN})
 
     # check the configuration
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -173,13 +173,24 @@ macro(add_qt_android_apk TARGET SOURCE_TARGET)
       COMMAND ${QT_ANDROID_QT_ROOT}/bin/androiddeployqt --verbose --output ${CMAKE_CURRENT_BINARY_DIR} --input ${CMAKE_CURRENT_BINARY_DIR}/qtdeploy.json --ant ${QT_ANDROID_ANT} ${INSTALL_OPTIONS} ${SIGN_OPTIONS}
     )
 
-    # create the custom target that invokes ANT to create the apk
-    add_custom_target(
-        ${TARGET}
-        COMMAND ${QT_ANDROID_ANT} ${ANT_CONFIG}
-        DEPENDS run_android_deploy_qt
-    )
+    if (ARG_TARGET_INSTALL)
+        # create the custom target that invokes ANT to create the apk
+        add_custom_target(
+            ${TARGET}
+            COMMAND ${QT_ANDROID_ANT} ${ANT_CONFIG}
+            DEPENDS run_android_deploy_qt
+        )
 
-    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_BINARY_DIR}\" --target \"${TARGET}\")")
+        # add the custom target to the install target
+        install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_BINARY_DIR}\" --target \"${TARGET}\")")
+    else()
+        # create the custom target that invokes ANT to create the apk and add it to the default build target
+        add_custom_target(
+            ${TARGET}
+            ALL
+            COMMAND ${QT_ANDROID_ANT} ${ANT_CONFIG}
+            DEPENDS run_android_deploy_qt
+        )
+    endif()
 
 endmacro()

--- a/AddQtAndroidApk.cmake
+++ b/AddQtAndroidApk.cmake
@@ -176,9 +176,10 @@ macro(add_qt_android_apk TARGET SOURCE_TARGET)
     # create the custom target that invokes ANT to create the apk
     add_custom_target(
         ${TARGET}
-        ALL
         COMMAND ${QT_ANDROID_ANT} ${ANT_CONFIG}
         DEPENDS run_android_deploy_qt
     )
+
+    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_BINARY_DIR}\" --target \"${TARGET}\")")
 
 endmacro()

--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,18 @@ add_qt_android_apk(my_app_apk my_app
 )
 ```
 
+### TARGET_INSTALL
+
+If this option is given, the APK will be created in the install phase only (e.g. when running `make install`) and not during the default build target (e.g. when running `make`).
+
+Example:
+
+```cmake
+add_qt_android_apk(my_app_apk my_app
+    TARGET_INSTALL
+)
+```
+
 ## Contact
 
 Laurent Gomila: laurent.gom@gmail.com


### PR DESCRIPTION
I'd like to create an .apk in a single run, and have stripped libraries (no symbols) in the .apk. The command for that is "cmake ...; make install/strip". I specify the stripped libraries as dependencies in add_qt_android_apk. The stripping is done by cmake during install (after the ALL target), so add_qt_android_apk cannot run before it. This patch moves add_qt_android_apk from the ALL target to the install target.
