### PR TITLE
Add a parameter do deploy extra plugins

### DIFF
--- a/AddQtAndroidApk.cmake
+++ b/AddQtAndroidApk.cmake
@@ -70,13 +70,14 @@ include(CMakeParseArguments)
 #     KEYSTORE ${CMAKE_CURRENT_LIST_DIR}/mykey.keystore myalias
 #     KEYSTORE_PASSWORD xxxx
 #     DEPENDS a_linked_target "path/to/a_linked_library.so" ...
+#     EXTRA_PLUGINS extra plugins (such as 3rd party QML imports) to be included in the apk
 #     INSTALL
 #)
 # 
 macro(add_qt_android_apk TARGET SOURCE_TARGET)
 
     # parse the macro arguments
-    cmake_parse_arguments(ARG "INSTALL" "NAME;PACKAGE_NAME;PACKAGE_SOURCES;KEYSTORE_PASSWORD" "DEPENDS;KEYSTORE" ${ARGN})
+    cmake_parse_arguments(ARG "INSTALL" "NAME;PACKAGE_NAME;PACKAGE_SOURCES;KEYSTORE_PASSWORD;EXTRA_PLUGINS" "DEPENDS;KEYSTORE" ${ARGN})
 
     # check the configuration
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -142,6 +143,10 @@ macro(add_qt_android_apk TARGET SOURCE_TARGET)
         endif()
         endforeach()
         set(QT_ANDROID_APP_EXTRA_LIBS "\"android-extra-libs\": \"${EXTRA_LIBS}\",")
+    endif()
+
+    if(ARG_EXTRA_PLUGINS)
+        set(QT_ANDROID_EXTRA_PLUGINS "\"android-extra-plugins\": \"${ARG_EXTRA_PLUGINS}\",")
     endif()
 
     # make sure that the output directory for the Android package exists

--- a/qtdeploy.json.in
+++ b/qtdeploy.json.in
@@ -12,5 +12,6 @@
  "android-package": "@QT_ANDROID_APP_PACKAGE_NAME@",
  "android-app-name": "@QT_ANDROID_APP_NAME@",
  @QT_ANDROID_APP_EXTRA_LIBS@
+ @QT_ANDROID_EXTRA_PLUGINS@
  "android-package-source-directory": "@QT_ANDROID_APP_PACKAGE_SOURCE_ROOT@"
 }


### PR DESCRIPTION
optional paramenter EXTRA_PLUGINS used to add the line
 "android-extra-plugins": in the deploy json file
this key is necessary if the app wants to use 3rd party
plugins, such as extra QML imports not part of Qt.

can be used like
add_qt_android_apk(target.apk target
     EXTRA_PLUGINS "${CMAKE_INSTALL_PREFIX}/lib/qml")
