### PR TITLE
fixes to get x86 build running

### DIFF
--- a/AndroidManifest.xml.in
+++ b/AndroidManifest.xml.in
@@ -28,6 +28,6 @@
 		</activity>
 	</application>
 	<supports-screens android:anyDensity="true" android:normalScreens="true" android:smallScreens="true" android:largeScreens="true"/>
-	<uses-sdk android:minSdkVersion="9" android:targetSdkVersion="19"/>
+	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21"/>
 	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/qtdeploy.json.in
+++ b/qtdeploy.json.in
@@ -3,7 +3,7 @@
  "qt": "@QT_ANDROID_QT_ROOT@",
  "sdk": "@QT_ANDROID_SDK_ROOT@",
  "ndk": "@QT_ANDROID_NDK_ROOT@",
- "toolchain-prefix": "@ANDROID_TOOLCHAIN_MACHINE_NAME@",
+ "toolchain-prefix": "@ANDROID_ABI@",
  "tool-prefix": "@ANDROID_TOOLCHAIN_MACHINE_NAME@",
  "toolchain-version": "@ANDROID_COMPILER_VERSION@",
  "ndk-host": "@ANDROID_NDK_HOST_SYSTEM_NAME@",


### PR DESCRIPTION
the first commit, regarding the minSdkVersion, may be specific to the x86 ABI, ,and of course this can be handled by using a custom AndroidManifest.

The second one, regarding qtdeploy.json, seems generic. The path that was constructed from the original value did not match on NDK 10 or 11, and for no prebuilt toolchain.
