### PR TITLE
Fixed incorrect tool prefix on Windows

### DIFF
--- a/AddQtAndroidApk.cmake
+++ b/AddQtAndroidApk.cmake
@@ -158,12 +158,13 @@ macro(add_qt_android_apk TARGET SOURCE_TARGET)
     # set some toolchain variables used by androiddeployqt;
     # unfortunately, Qt tries to build paths from these variables although these full paths
     # are already available in the toochain file, so we have to parse them
-    string(REGEX MATCH "${ANDROID_NDK}/toolchains/(.*)-(.*)/prebuilt/.*" ANDROID_TOOLCHAIN_PARSED ${ANDROID_TOOLCHAIN_ROOT})
+    string(REGEX MATCH "${ANDROID_NDK}/toolchains/(.*)-(.*)/prebuilt/.*/bin/(.*)-" ANDROID_TOOLCHAIN_PARSED ${ANDROID_TOOLCHAIN_PREFIX})
     if(ANDROID_TOOLCHAIN_PARSED)
         set(QT_ANDROID_TOOLCHAIN_PREFIX ${CMAKE_MATCH_1})
         set(QT_ANDROID_TOOLCHAIN_VERSION ${CMAKE_MATCH_2})
+        set(QT_ANDROID_TOOL_PREFIX ${CMAKE_MATCH_3})
     else()
-        message(FATAL_ERROR "Failed to parse ANDROID_TOOLCHAIN_ROOT to get toolchain prefix and version")
+        message(FATAL_ERROR "Failed to parse ANDROID_TOOLCHAIN_PREFIX to get toolchain prefix and version and tool prefix")
     endif()
 
     # make sure that the output directory for the Android package exists

--- a/qtdeploy.json.in
+++ b/qtdeploy.json.in
@@ -5,7 +5,7 @@
  "ndk": "@QT_ANDROID_NDK_ROOT@",
  "sdkBuildToolsRevision": "@QT_ANDROID_SDK_BUILDTOOLS_REVISION@",
  "toolchain-prefix": "@QT_ANDROID_TOOLCHAIN_PREFIX@",
- "tool-prefix": "@QT_ANDROID_TOOLCHAIN_PREFIX@",
+ "tool-prefix": "@QT_ANDROID_TOOL_PREFIX@",
  "toolchain-version": "@QT_ANDROID_TOOLCHAIN_VERSION@",
  "ndk-host": "@ANDROID_NDK_HOST_SYSTEM_NAME@",
  "target-architecture": "@ANDROID_ABI@",


### PR DESCRIPTION
On Windows there are errors due o the tthe incorrect tool-prefix.
For example, while building for android x86, it need to find i686-linux-android- commands instead of x86- (they do not exist).