### PR TITLE
Removing CMP0026 warning

### DIFF
--- a/qtdeploy.json.in
+++ b/qtdeploy.json.in
@@ -9,7 +9,7 @@
  "toolchain-version": "@QT_ANDROID_TOOLCHAIN_VERSION@",
  "ndk-host": "@ANDROID_NDK_HOST_SYSTEM_NAME@",
  "target-architecture": "@ANDROID_ABI@",
- "application-binary": "@QT_ANDROID_APP_PATH@",
+ "application-binary": "$<TARGET_FILE:@APP_TARGET@>",
  "android-package": "@QT_ANDROID_APP_PACKAGE_NAME@",
  "android-app-name": "@QT_ANDROID_APP_NAME@",
  "qml-root-path": "@CMAKE_SOURCE_DIR@",


### PR DESCRIPTION
I made some effort to remove the warning from newer cmake version that the CMP0026 OLD policy will be removed in future versions.

In this new version the target output location is set to the libs folder and thus doesn't have to be copied. After this it is also needed to let cmake expand the generator expression that I put in qtdeploy.json