### PR TITLE
Support build with Qt5.14, 5.15 with new qtandroiddeploy config file.

### DIFF
--- a/AndroidManifest.xml.in
+++ b/AndroidManifest.xml.in
@@ -4,6 +4,7 @@
     android:installLocation="auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:versionCode="@QT_ANDROID_APP_VERSION_CODE@">
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28"/>
     <application
         android:label="@QT_ANDROID_APP_NAME@"
         android:name="org.qtproject.qt5.android.bindings.QtApplication">
@@ -18,6 +19,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
 
+            <!-- Application arguments -->
+            <!-- meta-data android:name="android.app.arguments" android:value="arg1 arg2 arg3"/ -->
+            <!-- Application arguments -->
+
             <meta-data android:name="android.app.lib_name" android:value="-- %%INSERT_APP_LIB_NAME%% --"/>
             <meta-data android:name="android.app.qt_sources_resource_id" android:resource="@array/qt_sources"/>
             <meta-data android:name="android.app.repository" android:value="default"/>
@@ -25,16 +30,20 @@
             <meta-data android:name="android.app.bundled_libs_resource_id" android:resource="@array/bundled_libs"/>
             <!-- Deploy Qt libs as part of package -->
             <meta-data android:name="android.app.bundle_local_qt_libs" android:value="-- %%BUNDLE_LOCAL_QT_LIBS%% --"/>
-            <meta-data android:name="android.app.bundled_in_lib_resource_id" android:resource="@array/bundled_in_lib"/>
-            <meta-data android:name="android.app.bundled_in_assets_resource_id" android:resource="@array/bundled_in_assets"/>
+
             <!-- Run with local libs -->
             <meta-data android:name="android.app.use_local_qt_libs" android:value="-- %%USE_LOCAL_QT_LIBS%% --"/>
             <meta-data android:name="android.app.libs_prefix" android:value="/data/local/tmp/qt/"/>
-            <meta-data android:name="android.app.load_local_libs" android:value="-- %%INSERT_LOCAL_LIBS%% --"/>
+            <meta-data android:name="android.app.load_local_libs_resource_id" android:resource="@array/load_local_libs"/>
             <meta-data android:name="android.app.load_local_jars" android:value="-- %%INSERT_LOCAL_JARS%% --"/>
             <meta-data android:name="android.app.static_init_classes" android:value="-- %%INSERT_INIT_CLASSES%% --"/>
-             <!-- Used to specify custom system library path to run with local system libs -->
+            <!-- Used to specify custom system library path to run with local system libs -->
             <!-- <meta-data android:name="android.app.system_libs_prefix" android:value="/system/lib/"/> -->
+            <!--  Messages maps -->
+            <meta-data android:value="@string/ministro_not_found_msg" android:name="android.app.ministro_not_found_msg"/>
+            <meta-data android:value="@string/ministro_needed_msg" android:name="android.app.ministro_needed_msg"/>
+            <meta-data android:value="@string/fatal_error_msg" android:name="android.app.fatal_error_msg"/>
+            <meta-data android:value="@string/unsupported_android_version" android:name="android.app.unsupported_android_version"/>
             <!--  Messages maps -->
 
             <!-- Splash screen -->

--- a/build.gradle.in
+++ b/build.gradle.in
@@ -54,8 +54,13 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    // Do not compress Qt binary resources file
+    aaptOptions {
+        noCompress 'rcc'
+    }
+
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion @QT_ANDROID_NATIVE_API_LEVEL@
+        resConfigs "en"
     }
 }

--- a/qtdeploy.json.in
+++ b/qtdeploy.json.in
@@ -8,8 +8,11 @@
  "tool-prefix": "@QT_ANDROID_TOOL_PREFIX@",
  "toolchain-version": "@QT_ANDROID_TOOLCHAIN_VERSION@",
  "ndk-host": "@ANDROID_NDK_HOST_SYSTEM_NAME@",
+ "architectures": {
+    @QT_ANDROID_ARCHITECTURES@
+ },
  "target-architecture": "@ANDROID_ABI@",
- "application-binary": "@QT_ANDROID_APP_PATH@",
+ "application-binary": "@QT_ANDROID_APPLICATION_BINARY@",
  "android-package": "@QT_ANDROID_APP_PACKAGE_NAME@",
  "android-app-name": "@QT_ANDROID_APP_NAME@",
  "qml-root-path": "@CMAKE_SOURCE_DIR@",


### PR DESCRIPTION
Fix issue #35.
I tested compatibility with Qt 5.13.2.

From Qt 5.14 `qtandroiddeploy` require an object"architectures" in the deploy json file.
For example for armeabi-v7a, it will generate:
```json
"architectures": {
    "armeabi-v7a":"armeabi-v7a"
 },
```

* `stdcpp-path` : Should be to `$ANDROID_NDK/sources/cxx-stl/llvm-libc++/libs`, instead of path to the binary.
* `application-binary`: Name of the target, instead of path to the binary.

This PR doesn't support multi ABI build. It just work "like before" with Qt 5.14 qnd Qt 5.15.

Lesson learned from the past, you have everything in a clean commit on a dedicated branch.