### PR TITLE
Fix issue blocking creation of Release apks

### DIFF
--- a/AddQtAndroidApk.cmake
+++ b/AddQtAndroidApk.cmake
@@ -279,7 +279,7 @@ macro(add_qt_android_apk TARGET SOURCE_TARGET)
     # determine the build type to pass to androiddeployqt
     if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" AND NOT ARG_KEYSTORE)
         set(QT_ANDROID_BUILD_TYPE --debug)
-    elseif()
+    else()
         set(QT_ANDROID_BUILD_TYPE --release)
     endif()
 


### PR DESCRIPTION
Replace `elseif()` with `else` to fix the issue blocking creation of release apks

**Background:** 
I have been testing this really nice tool with _Qt 5.15.1 on macOS for creation of Android apks_. It works great except for one fact that, it creates a debug apk even if I have passed the `CMAKE_BUILD_TYPE` as `Release`. As a result, this blocks me from being able to create release apks and I always get a debug apk. 

This PR fixes the issue described above.