### PR TITLE
Allow passing a keystore file alias when signing a release apk

### DIFF
--- a/AddQtAndroidApk.cmake
+++ b/AddQtAndroidApk.cmake
@@ -259,8 +259,8 @@ macro(add_qt_android_apk TARGET SOURCE_TARGET)
     configure_file(${QT_ANDROID_SOURCE_DIR}/build.gradle.in ${QT_ANDROID_APP_BINARY_DIR}/build.gradle @ONLY)
 
     # check if the apk must be signed
-    if(ARG_KEYSTORE)
-        set(SIGN_OPTIONS --sign ${ARG_KEYSTORE})
+    if(ARG_KEYSTORE AND ARG_KEYSTORE_ALIAS)
+        set(SIGN_OPTIONS --sign ${ARG_KEYSTORE} ${ARG_KEYSTORE_ALIAS})
         if(ARG_KEYSTORE_PASSWORD)
             set(SIGN_OPTIONS ${SIGN_OPTIONS} --storepass ${ARG_KEYSTORE_PASSWORD})
         endif()


### PR DESCRIPTION
Allow passing a keystore file alias when signing a release apk because a release apk must be signed with a keystore file _along with its alias_.

Signing a release apk, needs the alias as well. Just providing the keystore file does not seem to be enough.
https://developer.android.com/studio/publish/app-signing?hl=ru#sign_release
https://reactnative.dev/docs/signed-apk-android

One could of course hack the `ARG_KEYSTORE` parameter and pass the keystore file along with appending the alias. But that  is hackish. This PR allows the user of this tool to cleanly pass an alias for the keystore with a separate cmake argument.